### PR TITLE
rats-tls: sgx rpm package info strip will cause to load sgx_stub_enclave.signed…

### DIFF
--- a/rats-tls/dist/rpm/rats_tls.spec.in
+++ b/rats-tls/dist/rpm/rats_tls.spec.in
@@ -1,6 +1,8 @@
 %define centos_base_release 1
 %define _debugsource_template %{nil}
 
+%global RATS_TLS_BINDIR /usr/share/rats-tls/samples
+
 %global _find_debuginfo_dwz_opts %{nil}
 %global _dwz_low_mem_die_limit 0
 %undefine _missing_build_ids_terminate_build
@@ -55,6 +57,13 @@ Conflicts: Name=rats-tls-occlum
 Conflicts: Name=rats-tls-tdx
 Conflicts: rats-tls-server
 Source10: rats-tls-sgx-filelist
+%define __enclave_tls_install_post \
+    cp %{_builddir}/%{PROJECT}-%{version}/%{name}/build/samples/sgx-stub-enclave/sgx_stub_enclave.signed.so %{?buildroot}%{RATS_TLS_BINDIR} %{nil}
+%define __spec_install_post \
+    %{?__debug_package:%{__debug_install_post}}\
+    %{__arch_install_post}\
+    %{__os_install_post}\
+    %{__enclave_tls_install_post}
 %endif
 
 %if %{mode} == tdx


### PR DESCRIPTION
….so failed

Fixes: #1547
Signed-off-by: zhiminghufighting <zhiming.hu@intel.com>