### PR TITLE
shim: upgrade distribution package to 2.8.0

### DIFF
--- a/shim/go.mod
+++ b/shim/go.mod
@@ -43,7 +43,7 @@ require (
 )
 
 replace (
-	github.com/docker/distribution => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
+	github.com/docker/distribution => github.com/docker/distribution v0.0.0-20220207154021-dcf66392d606
 	github.com/inclavare-containers/epm => ../epm
 	github.com/inclavare-containers/rune => ../rune
 

--- a/shim/go.sum
+++ b/shim/go.sum
@@ -135,6 +135,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/distribution v0.0.0-20220207154021-dcf66392d606/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible h1:dvc1KSkIYTVjZgHf/CTC2diTYC8PzhaA5sFISRfNVrE=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=


### PR DESCRIPTION
Upgrade distribution package to 2.8.0 to fix OCI
Manifest Type Confusion Issue.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>