### PR TITLE
rune: fix the wrong input parameter in KillPayload

### DIFF
--- a/rune/libenclave/runelet.go
+++ b/rune/libenclave/runelet.go
@@ -180,7 +180,7 @@ func forwardSignal(rt *runtime.EnclaveRuntimeWrapper, notifySignal <-chan os.Sig
 				return
 			case sig := <-notifySignal:
 				n := int(sig.(syscall.Signal))
-				err := rt.KillPayload(n, -1)
+				err := rt.KillPayload(-1, n)
 				if err != nil {
 					logrus.Debugf("failed to kill enclave runtime with signal %d", n)
 				}


### PR DESCRIPTION
The first parameter of func KillPayload(pid int, sig int)
is pid rather than sig.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>